### PR TITLE
Show error info, if available

### DIFF
--- a/cli/tui.go
+++ b/cli/tui.go
@@ -327,6 +327,14 @@ func (t *TUI) ObserveResponse(req *sdkv1.RunRequest, err error, httpRes *http.Re
 			n.done = terminalStatus(res.Status)
 			if d.Exit.TailCall != nil {
 				n = node{function: d.Exit.TailCall.Function} // reset
+			} else if res.Status != sdkv1.Status_STATUS_OK && d.Exit.Result != nil {
+				if e := d.Exit.Result.Error; e != nil && e.Type != "" {
+					if e.Message == "" {
+						n.error = fmt.Errorf("%s", e.Type)
+					} else {
+						n.error = fmt.Errorf("%s: %s", e.Type, e.Message)
+					}
+				}
 			}
 		case *sdkv1.RunResponse_Poll:
 			// noop
@@ -462,7 +470,7 @@ func tableHeaderView(functionColumnWidth int) string {
 		left(functionColumnWidth, tableHeaderStyle.Render("Function")) + " " +
 		right(8, tableHeaderStyle.Render("Attempts")) + " " +
 		right(10, tableHeaderStyle.Render("Duration")) + " " +
-		left(30, tableHeaderStyle.Render("Status")) +
+		left(40, tableHeaderStyle.Render("Status")) +
 		"\n"
 }
 
@@ -480,7 +488,7 @@ func tableRowView(r *row, functionColumnWidth int) string {
 		left(functionColumnWidth, r.function) + " " +
 		right(8, attemptsStr) + " " +
 		right(10, elapsedStr) + " " +
-		left(30, r.status) +
+		left(40, r.status) +
 		"\n"
 }
 


### PR DESCRIPTION
This PR updates the TUI to extract error details from the observed [`RunResponse`](https://github.com/dispatchrun/dispatch-proto/blob/b350ad1738d9eab96b78d21ea49ba04a08e7fcfc/dispatch/sdk/v1/function.proto#L77), and to prefer showing the error `type: message` over the status.

This fixes https://github.com/dispatchrun/dispatch/issues/29.

In the example from #29, the user would now see:

```
    Function             Attempts   Duration Status                                                                                    
    foo                         2     1.919s RuntimeError: oh no                                                                       
    └─ bar                      1      475ms RuntimeError: oh no 
```

Previously they would see:

```
    Function  Attempts   Duration Status
    foo              2     1.804s Permanent error
    └─ bar           2      471ms Permanent error
```

I don't think we have enough room to show both the status and the error details. The only thing you gain from seeing the status is knowing whether the failure is temporary or permanent. However, there are visual cues to help disambiguate the two, for example when a temporary error occurs, the spinner continues to spin, the duration continues to rise, and the error is shown in yellow rather than red. When a permanent error occurs, the error details are shown in red, and the spinner and duration stop changing.