### PR TITLE
Show error type and message in the logs

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -497,7 +497,8 @@ func invoke(ctx context.Context, client *http.Client, url, requestID string, bri
 				logger.Info("function yielded", "function", runRequest.Function, "calls", len(d.Poll.Calls))
 			}
 		default:
-			logger.Warn("function call failed", "function", runRequest.Function, "status", statusString(runResponse.Status))
+			err := runResponse.GetExit().GetResult().GetError()
+			logger.Warn("function call failed", "function", runRequest.Function, "status", statusString(runResponse.Status), "error_type", err.GetType(), "error_message", err.GetMessage())
 		}
 		if observer != nil {
 			observer.ObserveResponse(&runRequest, nil, endpointRes, &runResponse)


### PR DESCRIPTION
The function call table shows the latest error that occurs, but if it's a temporary error the status is wiped as follow-up attempts are made. This PR adds the error type and message to the logs, so that you can see the same information in chronological form.