### PR TITLE
Color fixes

### DIFF
--- a/cli/color.go
+++ b/cli/color.go
@@ -6,8 +6,9 @@ var (
 	defaultColor = lipgloss.NoColor{}
 
 	// See https://www.hackitu.de/termcolor256/
-	grayColor   = lipgloss.ANSIColor(102)
-	redColor    = lipgloss.ANSIColor(124)
-	greenColor  = lipgloss.ANSIColor(34)
-	yellowColor = lipgloss.ANSIColor(142)
+	grayColor    = lipgloss.ANSIColor(102)
+	redColor     = lipgloss.ANSIColor(124)
+	greenColor   = lipgloss.ANSIColor(34)
+	yellowColor  = lipgloss.ANSIColor(142)
+	magentaColor = lipgloss.ANSIColor(127)
 )

--- a/cli/color.go
+++ b/cli/color.go
@@ -4,8 +4,10 @@ import "github.com/charmbracelet/lipgloss"
 
 var (
 	defaultColor = lipgloss.NoColor{}
-	grayColor    = lipgloss.Color("#7D7D7D")
-	redColor     = lipgloss.Color("#FF0000")
-	greenColor   = lipgloss.Color("#00FF00")
-	yellowColor  = lipgloss.Color("#FFAA00")
+
+	// See https://www.hackitu.de/termcolor256/
+	grayColor   = lipgloss.ANSIColor(102)
+	redColor    = lipgloss.ANSIColor(124)
+	greenColor  = lipgloss.ANSIColor(34)
+	yellowColor = lipgloss.ANSIColor(142)
 )

--- a/cli/color.go
+++ b/cli/color.go
@@ -3,9 +3,9 @@ package cli
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	grayColor   = lipgloss.Color("#7D7D7D")
-	whiteColor  = lipgloss.Color("#FFFFFF")
-	redColor    = lipgloss.Color("#FF0000")
-	greenColor  = lipgloss.Color("#00FF00")
-	yellowColor = lipgloss.Color("#FFAA00")
+	defaultColor = lipgloss.NoColor{}
+	grayColor    = lipgloss.Color("#7D7D7D")
+	redColor     = lipgloss.Color("#FF0000")
+	greenColor   = lipgloss.Color("#00FF00")
+	yellowColor  = lipgloss.Color("#FFAA00")
 )

--- a/cli/config.go
+++ b/cli/config.go
@@ -23,8 +23,6 @@ var (
 	DispatchConsoleUrl       string
 
 	DispatchConfigPath string
-
-	Color bool
 )
 
 func init() {
@@ -52,18 +50,6 @@ func init() {
 			configHome = "$HOME/.config"
 		}
 		DispatchConfigPath = filepath.Join(os.ExpandEnv(configHome), "dispatch/config.toml")
-	}
-
-	// Enable color when connected to a terminal, unless the NO_COLOR
-	// environment variable is set (to any value). If stdout or stderr are
-	// redirected, colors are disabled. If the FORCE_COLOR environment
-	// variable is set (to any value), color is unconditionally enabled.
-	Color = isTerminal(os.Stdout) && isTerminal(os.Stderr)
-	if os.Getenv("NO_COLOR") != "" {
-		Color = false
-	}
-	if os.Getenv("FORCE_COLOR") != "" {
-		Color = true
 	}
 }
 

--- a/cli/log.go
+++ b/cli/log.go
@@ -15,8 +15,8 @@ var (
 	logTimeStyle = lipgloss.NewStyle().Foreground(grayColor)
 	logAttrStyle = lipgloss.NewStyle().Foreground(grayColor)
 
-	logDebugStyle = lipgloss.NewStyle().Foreground(whiteColor)
-	logInfoStyle  = lipgloss.NewStyle().Foreground(whiteColor)
+	logDebugStyle = lipgloss.NewStyle().Foreground(defaultColor)
+	logInfoStyle  = lipgloss.NewStyle().Foreground(defaultColor)
 	logWarnStyle  = lipgloss.NewStyle().Foreground(yellowColor)
 	logErrorStyle = lipgloss.NewStyle().Foreground(redColor)
 )

--- a/cli/run.go
+++ b/cli/run.go
@@ -24,6 +24,7 @@ import (
 
 	sdkv1 "buf.build/gen/go/stealthrocket/dispatch-proto/protocolbuffers/go/dispatch/sdk/v1"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -46,6 +47,12 @@ var httpClient = &http.Client{
 	Transport: http.DefaultTransport,
 	Timeout:   pollTimeout,
 }
+
+var (
+	dispatchLogPrefixStyle  = lipgloss.NewStyle().Foreground(greenColor)
+	appLogPrefixStyle       = lipgloss.NewStyle().Foreground(magentaColor)
+	logPrefixSeparatorStyle = lipgloss.NewStyle().Foreground(grayColor)
+)
 
 func runCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -105,7 +112,7 @@ previous run.`, defaultEndpoint),
 			}
 			dispatchPrefix := []byte(pad("dispatch", prefixWidth) + " | ")
 			if Color {
-				dispatchPrefix = []byte("\033[32m" + pad("dispatch", prefixWidth) + " \033[90m|\033[0m ")
+				dispatchPrefix = []byte(dispatchLogPrefixStyle.Render(pad("dispatch", prefixWidth)) + logPrefixSeparatorStyle.Render(" | "))
 			}
 			slog.SetDefault(slog.New(&slogHandler{
 				stream: &prefixLogWriter{
@@ -278,7 +285,7 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 			appPrefix := []byte(pad(arg0, prefixWidth) + " | ")
 			appSuffix := []byte("\n")
 			if Color {
-				appPrefix = []byte("\033[35m" + pad(arg0, prefixWidth) + " \033[90m|\033[0m ")
+				appPrefix = []byte(appLogPrefixStyle.Render(pad(arg0, prefixWidth)) + logPrefixSeparatorStyle.Render(" | "))
 			}
 			go printPrefixedLines(logWriter, stdout, appPrefix, appSuffix)
 			go printPrefixedLines(logWriter, stderr, appPrefix, appSuffix)

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -29,11 +29,11 @@ var (
 	viewportStyle = lipgloss.NewStyle().Margin(1, 2)
 
 	// Styles for the dispatch_ ASCII logo.
-	logoStyle           = lipgloss.NewStyle().Foreground(whiteColor)
+	logoStyle           = lipgloss.NewStyle().Foreground(defaultColor)
 	logoUnderscoreStyle = lipgloss.NewStyle().Foreground(greenColor)
 
 	// Style for the table of function calls.
-	tableHeaderStyle = lipgloss.NewStyle().Foreground(whiteColor).Bold(true)
+	tableHeaderStyle = lipgloss.NewStyle().Foreground(defaultColor).Bold(true)
 
 	// Styles for function names and statuses in the table.
 	pendingStyle = lipgloss.NewStyle().Foreground(grayColor)


### PR DESCRIPTION
This PR fixes a few issues with colors:
* we avoid using white, in case the user has a light/white background, instead using `lipgloss.NoColor` which is presumably white or black depending on the theme/background
* we use ANSI(256) colors now, and use a slightly darker shade of green/yellow/red that looks better on light and dark background
* we use lipgloss to style the log prefixes, and avoid manually parsing color related environment variables (which lipgloss does for us)

This fixes #31.