### PR TITLE
tui: fix how auth errors are displayed in TUI mode

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -5,7 +5,7 @@ import "fmt"
 type authError struct{}
 
 func (authError) Error() string {
-	const message = "Authentication error when contacting the Dispatch API"
+	const message = "Authentication error"
 	var detail string
 	switch DispatchApiKeyLocation {
 	case "env":

--- a/cli/run.go
+++ b/cli/run.go
@@ -232,13 +232,14 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 						if ctx.Err() != nil {
 							return
 						}
-						switch e := err.(type) {
-						case authError:
-							failure(e.Error())
-							return
-						default:
-							slog.Warn(err.Error())
+						slog.Warn(err.Error())
+
+						if tui != nil {
+							if _, ok := err.(authError); ok {
+								tui.SetError(err)
+							}
 						}
+
 						time.Sleep(1 * time.Second)
 						continue
 					} else if res == nil {


### PR DESCRIPTION
This fixes #43.

Instead of printing errors when an authentication error occurs, which conflicts with TUI rendering, we instead notify the TUI of the error so that it can render it on the status line.