### PR TITLE
run: use base62 session IDs

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -613,7 +613,7 @@ func pad(s string, width int) string {
 }
 
 func randomSessionID() string {
-	var b [8]byte
+	var b [16]byte
 	_, err := rand.Read(b[:])
 	if err != nil {
 		panic(err)

--- a/cli/run.go
+++ b/cli/run.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -25,7 +27,6 @@ import (
 	sdkv1 "buf.build/gen/go/stealthrocket/dispatch-proto/protocolbuffers/go/dispatch/sdk/v1"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 )
@@ -119,7 +120,7 @@ previous run.`, defaultEndpoint),
 			}))
 
 			if BridgeSession == "" {
-				BridgeSession = uuid.New().String()
+				BridgeSession = randomSessionID()
 			}
 
 			if !Verbose && tui == nil {
@@ -609,4 +610,15 @@ func pad(s string, width int) string {
 		return s + strings.Repeat(" ", width-len(s))
 	}
 	return s
+}
+
+func randomSessionID() string {
+	var b [8]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		panic(err)
+	}
+	var i big.Int
+	i.SetBytes(b[:])
+	return i.Text(62) // base62
 }

--- a/cli/style.go
+++ b/cli/style.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,6 +12,7 @@ var (
 	dialogBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#874BFD")).
+			Margin(1, 2).
 			Padding(1, 2).
 			BorderTop(true).
 			BorderLeft(true).
@@ -119,11 +119,5 @@ func simple(msg string) {
 }
 
 func dialog(msg string, args ...interface{}) {
-	docStyle := lipgloss.NewStyle().Padding(1, 2, 1, 2)
-	var doc strings.Builder
-	doc.WriteString(lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		dialogBoxStyle.Copy().Align(lipgloss.Left).Render(fmt.Sprintf(msg, args...)),
-	))
-	fmt.Println(docStyle.Render(doc.String()))
+	fmt.Println(dialogBoxStyle.Render(fmt.Sprintf(msg, args...)))
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.9.1
-	github.com/google/uuid v1.6.0
 	github.com/muesli/reflow v0.3.0
 	github.com/nlpodyssey/gopickle v0.3.0
 	github.com/pelletier/go-toml/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=


### PR DESCRIPTION
This PR replaces the uuidv4 session IDs (e.g. `5dd1adcc-968f-4805-96a3-d551e0b7b986`) with a random 128-bit base62 string (e.g. `5KtjiELR4cK5pZDA89saUz`).