### PR TITLE
run: kill child process if CLI panics

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -141,7 +141,7 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 				if err := recover(); err != nil {
 					// Don't leave behind a dangling process if a panic occurs.
 					if cmd != nil && cmd.Process != nil {
-						cmd.Process.Kill()
+						_ = cmd.Process.Kill()
 					}
 					panic(err)
 				}


### PR DESCRIPTION
This PR ensures we kill the child process if the CLI exits with an unexpected error.

[`Pdeathsig`](https://github.com/dispatchrun/dispatch/blob/aac1d73ff5f49721d724ae8fc63c798be0f0d140/cli/run_linux.go#L7) helps on Linux, but it isn't available elsewhere, e.g. macOS.

I've reworked how we create background goroutines so that if a panic occurs we manually kill the child process.