### PR TITLE
tui: prevent one row from being truncated

### DIFF
--- a/cli/tui.go
+++ b/cli/tui.go
@@ -438,6 +438,7 @@ func (t *TUI) functionsView(now time.Time) string {
 
 		rows.reset()
 	}
+	b.WriteByte('\n')
 	return b.String()
 }
 


### PR DESCRIPTION
This fixes an issue where one function call is sometimes truncated from the TUI.