### PR TITLE
run: improve formatting of Python input/output values

### DIFF
--- a/cli/any.go
+++ b/cli/any.go
@@ -4,20 +4,14 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/charmbracelet/lipgloss"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-var (
-	anyTypeStyle = lipgloss.NewStyle().Foreground(grayColor)
-	anyNilStyle  = lipgloss.NewStyle().Foreground(grayColor)
-)
-
 func anyString(any *anypb.Any) string {
 	if any == nil {
-		return anyNilStyle.Render("nil")
+		return "nil"
 	}
 	switch any.TypeUrl {
 	case "type.googleapis.com/google.protobuf.BytesValue":
@@ -29,8 +23,7 @@ func anyString(any *anypb.Any) string {
 			return s
 		}
 	}
-	return anyTypeStyle.Render(fmt.Sprintf("<%s>", any.TypeUrl))
-
+	return fmt.Sprintf("%s(?)", any.TypeUrl)
 }
 
 func anyBytesString(any *anypb.Any) (string, error) {

--- a/cli/any.go
+++ b/cli/any.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/charmbracelet/lipgloss"
 	"google.golang.org/protobuf/proto"
@@ -20,10 +21,13 @@ func anyString(any *anypb.Any) string {
 	}
 	switch any.TypeUrl {
 	case "type.googleapis.com/google.protobuf.BytesValue":
-		if s, err := anyBytesString(any); err == nil && s != "" {
+		s, err := anyBytesString(any)
+		if err != nil {
+			slog.Debug("cannot parse input/output value", "error", err)
+			// fallthrough
+		} else {
 			return s
 		}
-		// Suppress the error; render the type only.
 	}
 	return anyTypeStyle.Render(fmt.Sprintf("<%s>", any.TypeUrl))
 

--- a/cli/python.go
+++ b/cli/python.go
@@ -49,11 +49,10 @@ func pythonValueString(value interface{}) (string, error) {
 		return pythonSetString(v)
 	case *pythonArgumentsObject:
 		return pythonArgumentsString(v)
-	case *types.GenericClass:
+	case *genericClass:
 		return fmt.Sprintf("%s.%s", v.Module, v.Name), nil
-	case *types.GenericObject:
-		s, _ := pythonValueString(v.Class)
-		return fmt.Sprintf("%s(?)", s), nil
+	case *genericObject:
+		return pythonGenericObjectString(v)
 	default:
 		return "", fmt.Errorf("unsupported Python value: %T", value)
 	}
@@ -183,6 +182,42 @@ func pythonArgumentsString(a *pythonArgumentsObject) (string, error) {
 
 	b.WriteByte(')')
 	return b.String(), nil
+}
+
+func pythonGenericObjectString(o *genericObject) (string, error) {
+	var b strings.Builder
+	b.WriteString(o.class.Name)
+	b.WriteByte('(')
+
+	for i, e := 0, o.dict.List.Front(); e != nil; i++ {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		entry := e.Value.(*types.OrderedDictEntry)
+
+		var keyStr string
+		if s, ok := entry.Key.(string); ok {
+			keyStr = s
+		} else {
+			var err error
+			keyStr, err = pythonValueString(entry.Key)
+			if err != nil {
+				return "", err
+			}
+		}
+		b.WriteString(kwargStyle.Render(keyStr + "="))
+
+		valueStr, err := pythonValueString(entry.Value)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(valueStr)
+
+		e = e.Next()
+	}
+
+	b.WriteByte(')')
+	return b.String(), nil
 
 }
 
@@ -191,8 +226,12 @@ func findPythonClass(module, name string) (interface{}, error) {
 	if module == "dispatch.proto" && name == "Arguments" {
 		return &pythonArgumentsClass{}, nil
 	}
+	// If a custom class is encountered, we don't have enough information
+	// to be able to format it. In many cases though (e.g. dataclasses),
+	// it's sufficient to collect and format the module/name of the class,
+	// and then data that arrives through PyDictSettable interface.
 	slog.Debug("parsing Python value", "module", module, "name", name)
-	return types.NewGenericClass(module, name), nil
+	return &genericClass{&types.GenericClass{Module: module, Name: name}}, nil
 }
 
 type pythonArgumentsClass struct{}
@@ -222,5 +261,23 @@ func (a *pythonArgumentsObject) PyDictSet(key, value interface{}) error {
 	default:
 		return fmt.Errorf("unexpected key: %v", key)
 	}
+	return nil
+}
+
+type genericClass struct {
+	*types.GenericClass
+}
+
+func (c *genericClass) PyNew(args ...interface{}) (interface{}, error) {
+	return &genericObject{c, types.NewOrderedDict()}, nil
+}
+
+type genericObject struct {
+	class *genericClass
+	dict  *types.OrderedDict
+}
+
+func (o *genericObject) PyDictSet(key, value interface{}) error {
+	o.dict.Set(key, value)
 	return nil
 }

--- a/cli/python.go
+++ b/cli/python.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -190,6 +191,7 @@ func findPythonClass(module, name string) (interface{}, error) {
 	if module == "dispatch.proto" && name == "Arguments" {
 		return &pythonArgumentsClass{}, nil
 	}
+	slog.Debug("parsing Python value", "module", module, "name", name)
 	return types.NewGenericClass(module, name), nil
 }
 

--- a/cli/python.go
+++ b/cli/python.go
@@ -230,7 +230,7 @@ func findPythonClass(module, name string) (interface{}, error) {
 	// to be able to format it. In many cases though (e.g. dataclasses),
 	// it's sufficient to collect and format the module/name of the class,
 	// and then data that arrives through PyDictSettable interface.
-	slog.Debug("parsing Python value", "module", module, "name", name)
+	slog.Debug("deserializing Python class", "module", module, "name", name)
 	return &genericClass{&types.GenericClass{Module: module, Name: name}}, nil
 }
 


### PR DESCRIPTION
The pickle library we're using ([gopickle](https://github.com/nlpodyssey/gopickle)) uses a `types.GenericClass` and `types.GenericObject` to represent custom classes and objects found in a pickle stream. For the common case where the class is a `@dataclass`, these types aren't sufficient; an error occurs when the pickle library tries to set `__dict__` properties, since `*types.GenericObject` doesn't implement `types.PyDictSettable`. This PR updates the formatter to instead use a custom generic object type which implements `PyDictSettable`. The result is that we can properly format data classes.

I've also updated the formatting layer to log more information when it encounters a Python value it can't parse.