### PR TITLE
run: improve error messages when local application can't be reached or misbehaves

### DIFF
--- a/cli/tui.go
+++ b/cli/tui.go
@@ -605,9 +605,13 @@ func (t *TUI) detailView(id DispatchID) string {
 					}
 				}
 			} else if c := rt.response.httpStatus; c != 0 {
-				add("Error", errorStyle.Render(fmt.Sprintf("%d %s", c, http.StatusText(c))))
+				style := errorStyle
+				if !terminalHTTPStatusCode(c) {
+					style = retryStyle
+				}
+				add("Error", style.Render(fmt.Sprintf("%d %s", c, http.StatusText(c))))
 			} else if rt.response.err != nil {
-				add("Error", errorStyle.Render(rt.response.err.Error()))
+				add("Error", retryStyle.Render(rt.response.err.Error()))
 			}
 
 			latency := rt.response.ts.Sub(rt.request.ts)


### PR DESCRIPTION
This PR improves the error messages that the user sees when the local application can't be reached via the configurable `-e,--endpoint`, or it misbehaves in some way.

We now enrich error messages prior to notifying the TUI, and use shorter error messages.