### PR TITLE
run: only show function table header once

### DIFF
--- a/cli/tui.go
+++ b/cli/tui.go
@@ -438,7 +438,9 @@ func (t *TUI) functionsView(now time.Time) string {
 		functionColumnWidth := max(9, min(50, maxFunctionWidth))
 
 		// Render the table.
-		b.WriteString(t.tableHeaderView(functionColumnWidth))
+		if i == 0 {
+			b.WriteString(t.tableHeaderView(functionColumnWidth))
+		}
 		for i := range rows.rows {
 			b.WriteString(t.tableRowView(&rows.rows[i], functionColumnWidth))
 		}


### PR DESCRIPTION
When there are a lot of independent function calls with shallow call hierarchies, the extra table headers add a lot of unnecessary noise. This PR updates the functions view to show the table header only once, on the first function call table.