### PR TITLE
Fixes #66 by forcing lipgloss to have no color output

### DIFF
--- a/cli/switch_test.go
+++ b/cli/switch_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,6 +118,7 @@ func TestSwitchCommand(t *testing.T) {
 }
 
 func setupConfig(t *testing.T, tc testCase) string {
+	lipgloss.SetColorProfile(termenv.Ascii)
 	tempDir := t.TempDir() // unique temp dir for each test and cleaned up after test finishes
 	configPath := filepath.Join(tempDir, "config.yaml")
 	if tc.configExists {


### PR DESCRIPTION
This imports both lipgloss and termenv, and then uses `SetColorProfile()` to use `termenv.Ascii` which has no-color. I placed this within the setupConfig so it applies to all tests that end up calling the `setupConfig()`. It could also be moved to directly within `TestSwitchCommand()`. I'm not sure which you would prefer.

This fixes Issue #66. 