### PR TITLE
fix(version): fixes dispatch version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ fmt:
 	$(GO) fmt ./...
 
 dispatch:
-	$(GO) build -o $(DISPATCH) .
-
+	@echo "Building dispatch binary..."
+	$(eval VERSION := $(shell git describe --tags --abbrev=0 | cut -c 2-))
+	$(eval COMMIT := $(shell git rev-parse --short=8 HEAD))
+	$(GO) build -ldflags "-X main.Version=$(VERSION) -X main.Revision=$(COMMIT)" -o $(DISPATCH) .
 clean:
 	rm -rf ./build
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"runtime/debug"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"os/exec"
 )
 
 func versionCommand() *cobra.Command {
@@ -19,17 +21,19 @@ func versionCommand() *cobra.Command {
 }
 
 func version() string {
-	version := "devel"
+	version := "devel "
+	output, _ := exec.Command("git", "describe", "--tags", "--abbrev=0").Output()
 	if info, ok := debug.ReadBuildInfo(); ok {
 		switch info.Main.Version {
 		case "":
 		case "(devel)":
+			version += strings.TrimSpace(string(output)[1:]) + ", build"
 		default:
 			version = info.Main.Version
 		}
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
-				version += " " + setting.Value
+				version += " " + setting.Value[:8]
 			}
 		}
 	}

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,12 +1,11 @@
 package cli
 
 import (
-	"runtime/debug"
-	"strings"
-
 	"github.com/spf13/cobra"
-	"os/exec"
 )
+
+var Version string
+var Revision string
 
 func versionCommand() *cobra.Command {
 	return &cobra.Command{
@@ -21,21 +20,10 @@ func versionCommand() *cobra.Command {
 }
 
 func version() string {
-	version := "devel "
-	output, _ := exec.Command("git", "describe", "--tags", "--abbrev=0").Output()
-	if info, ok := debug.ReadBuildInfo(); ok {
-		switch info.Main.Version {
-		case "":
-		case "(devel)":
-			version += strings.TrimSpace(string(output)[1:]) + ", build"
-		default:
-			version = info.Main.Version
-		}
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				version += " " + setting.Value[:8]
-			}
-		}
-	}
-	return version
+	return Version + ", build " + Revision
+}
+
+func InitVersions(version string, revision string) {
+	Version = version
+	Revision = revision
 }

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var versionText = "dispatch version devel"
+var versionText = "dispatch version"
 
 func TestVersionCommand(t *testing.T) {
 	t.Run("Print the version (test runtime)", func(t *testing.T) {
@@ -24,7 +24,7 @@ func TestVersionCommand(t *testing.T) {
 			t.Fatalf("Received unexpected error: %v", err)
 		}
 
-		assert.Equal(t, versionText+" \n", stdout.String())
+		assert.Equal(t, versionText+" , build \n", stdout.String())
 	})
 
 	t.Run("Print the version (binary)", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,13 @@ import (
 	"github.com/dispatchrun/dispatch/cli"
 )
 
+var (
+	Version  string
+	Revision string
+)
+
 func main() {
+	cli.InitVersions(Version, Revision)
 	if err := cli.Main(); err != nil {
 		// The error is logged by the CLI library.
 		// No need to log here too.


### PR DESCRIPTION
This PR fixes the issue #64 
on dispatch version command, it will now print git tag version an 1st 8 characters of git revision
