### PR TITLE
Fix Windows build and build on Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOPRIVATE: github.com/stealthrocket,buf.build/gen/go
+  GOPRIVATE: github.com/dispatchrun,buf.build/gen/go
   GOVERSION: 1.22.0
 
 jobs:
@@ -39,7 +39,10 @@ jobs:
           skip-pkg-cache: true
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    concurrency:
-      group: tests-${{ github.workflow }}-${{ github.event.number || github.ref }}
-      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read
@@ -43,6 +40,9 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    concurrency:
+      group: ${{ matrix.os }}-${{ github.workflow }}-${{ github.event.number || github.ref }}
+      cancel-in-progress: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    concurrency:
+      group: tests-${{ github.workflow }}-${{ github.event.number || github.ref }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read

--- a/cli/run.go
+++ b/cli/run.go
@@ -205,9 +205,7 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 							s = os.Kill
 						}
 						if cmd.Process != nil && cmd.Process.Pid > 0 {
-							// Sending the signal to -pid sends it to all processes
-							// in the process group.
-							_ = syscall.Kill(-cmd.Process.Pid, s.(syscall.Signal))
+							killProcess(cmd.Process, s.(syscall.Signal))
 						}
 					}
 				}

--- a/cli/run_darwin.go
+++ b/cli/run_darwin.go
@@ -1,7 +1,16 @@
 package cli
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func setSysProcAttr(attr *syscall.SysProcAttr) {
 	attr.Setpgid = true
+}
+
+func killProcess(process *os.Process, signal os.Signal) {
+	// Sending the signal to -pid sends it to all processes
+	// in the process group.
+	_ = syscall.Kill(-process.Pid, signal.(syscall.Signal))
 }

--- a/cli/run_default.go
+++ b/cli/run_default.go
@@ -2,6 +2,13 @@
 
 package cli
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func setSysProcAttr(attr *syscall.SysProcAttr) {}
+
+func killProcess(process *os.Process, _ os.Signal) {
+	process.Kill()
+}

--- a/cli/run_linux.go
+++ b/cli/run_linux.go
@@ -1,8 +1,17 @@
 package cli
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func setSysProcAttr(attr *syscall.SysProcAttr) {
 	attr.Setpgid = true
 	attr.Pdeathsig = syscall.SIGTERM
+}
+
+func killProcess(process *os.Process, signal os.Signal) {
+	// Sending the signal to -pid sends it to all processes
+	// in the process group.
+	_ = syscall.Kill(-process.Pid, signal.(syscall.Signal))
 }

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -35,93 +35,98 @@ func TestRunCommand(t *testing.T) {
 		assert.Regexp(t, "Error: failed to load env file from .+"+path+": open non-existent\\.env: "+errMsg, buff.String())
 	})
 
-	t.Run("Run with env file", func(t *testing.T) {
-		t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Run("Run with env file", func(t *testing.T) {
+			t.Parallel()
 
-		envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
-		defer os.Remove(envFile)
-		if err != nil {
-			t.Fatalf("Failed to write env file: %v", err)
-		}
+			envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
+			defer os.Remove(envFile)
+			if err != nil {
+				t.Fatalf("Failed to write env file: %v", err)
+			}
 
-		buff, err := execRunCommand(&[]string{}, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
-		if err != nil {
-			t.Fatal(err.Error())
-		}
+			buff, err := execRunCommand(&[]string{}, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 
-		result, found := findEnvVariableInLogs(&buff)
-		if !found {
-			t.Fatalf("Expected printenv in the output: %s", buff.String())
-		}
-		assert.Equal(t, "rick_sanchez", result, fmt.Sprintf("Expected 'printenv | rick_sanchez' in the output, got 'printenv | %s'", result))
-	})
+			result, found := findEnvVariableInLogs(&buff)
+			if !found {
+				t.Fatalf("Expected printenv in the output: %s", buff.String())
+			}
+			assert.Equal(t, "rick_sanchez", result, fmt.Sprintf("Expected 'printenv | rick_sanchez' in the output, got 'printenv | %s'", result))
+		})
+	}
 
-	t.Run("Run with env variable", func(t *testing.T) {
-		t.Parallel()
+	// FIXME(@chicoxyzzy): Fix tests to work on Windows
+	if runtime.GOOS != "windows" {
+		t.Run("Run with env variable", func(t *testing.T) {
+			t.Parallel()
 
-		// Set environment variables
-		envVars := []string{"CHARACTER=morty_smith"}
+			// Set environment variables
+			envVars := []string{"CHARACTER=morty_smith"}
 
-		buff, err := execRunCommand(&envVars, "run", "--", "printenv", "CHARACTER")
-		if err != nil {
-			t.Fatal(err.Error())
-		}
+			buff, err := execRunCommand(&envVars, "run", "--", "printenv", "CHARACTER")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 
-		result, found := findEnvVariableInLogs(&buff)
-		if !found {
-			t.Fatalf("Expected printenv in the output: %s", buff.String())
-		}
-		assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
-	})
+			result, found := findEnvVariableInLogs(&buff)
+			if !found {
+				t.Fatalf("Expected printenv in the output: %s", buff.String())
+			}
+			assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
+		})
 
-	t.Run("Run with env variable in command line has priority over the one in the env file", func(t *testing.T) {
-		t.Parallel()
+		t.Run("Run with env variable in command line has priority over the one in the env file", func(t *testing.T) {
+			t.Parallel()
 
-		envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
-		defer os.Remove(envFile)
-		if err != nil {
-			t.Fatalf("Failed to write env file: %v", err)
-		}
+			envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
+			defer os.Remove(envFile)
+			if err != nil {
+				t.Fatalf("Failed to write env file: %v", err)
+			}
 
-		// Set environment variables
-		envVars := []string{"CHARACTER=morty_smith"}
-		buff, err := execRunCommand(&envVars, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
-		if err != nil {
-			t.Fatal(err.Error())
-		}
+			// Set environment variables
+			envVars := []string{"CHARACTER=morty_smith"}
+			buff, err := execRunCommand(&envVars, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 
-		result, found := findEnvVariableInLogs(&buff)
-		if !found {
-			t.Fatalf("Expected printenv in the output: %s", buff.String())
-		}
-		assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
-	})
+			result, found := findEnvVariableInLogs(&buff)
+			if !found {
+				t.Fatalf("Expected printenv in the output: %s", buff.String())
+			}
+			assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
+		})
 
-	t.Run("Run with env variable in local env vars has priority over the one in the env file", func(t *testing.T) {
-		// Do not use t.Parallel() here as we are manipulating the environment!
+		t.Run("Run with env variable in local env vars has priority over the one in the env file", func(t *testing.T) {
+			// Do not use t.Parallel() here as we are manipulating the environment!
 
-		// Set environment variables
-		os.Setenv("CHARACTER", "morty_smith")
-		defer os.Unsetenv("CHARACTER")
+			// Set environment variables
+			os.Setenv("CHARACTER", "morty_smith")
+			defer os.Unsetenv("CHARACTER")
 
-		envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
-		defer os.Remove(envFile)
+			envFile, err := createEnvFile(t.TempDir(), []byte("CHARACTER=rick_sanchez"))
+			defer os.Remove(envFile)
 
-		if err != nil {
-			t.Fatalf("Failed to write env file: %v", err)
-		}
+			if err != nil {
+				t.Fatalf("Failed to write env file: %v", err)
+			}
 
-		buff, err := execRunCommand(&[]string{}, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
-		if err != nil {
-			t.Fatal(err.Error())
-		}
+			buff, err := execRunCommand(&[]string{}, "run", "--env-file", envFile, "--", "printenv", "CHARACTER")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 
-		result, found := findEnvVariableInLogs(&buff)
-		if !found {
-			t.Fatalf("Expected printenv in the output: %s\n\n", buff.String())
-		}
-		assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
-	})
+			result, found := findEnvVariableInLogs(&buff)
+			if !found {
+				t.Fatalf("Expected printenv in the output: %s\n\n", buff.String())
+			}
+			assert.Equal(t, "morty_smith", result, fmt.Sprintf("Expected 'printenv | morty_smith' in the output, got 'printenv | %s'", result))
+		})
+	}
 }
 
 func execRunCommand(envVars *[]string, arg ...string) (bytes.Buffer, error) {

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -26,7 +27,12 @@ func TestRunCommand(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		assert.Regexp(t, "Error: failed to load env file from .+/dispatch/cli/non-existent.env: open non-existent.env: no such file or directory\n", buff.String())
+		errMsg := "no such file or directory\n"
+		path := regexp.QuoteMeta(filepath.FromSlash("/dispatch/cli/non-existent.env"))
+		if runtime.GOOS == "windows" {
+			errMsg = "The system cannot find the file specified.\n"
+		}
+		assert.Regexp(t, "Error: failed to load env file from .+"+path+": open non-existent\\.env: "+errMsg, buff.String())
 	})
 
 	t.Run("Run with env file", func(t *testing.T) {

--- a/cli/run_windows.go
+++ b/cli/run_windows.go
@@ -1,7 +1,0 @@
-package cli
-
-import "os"
-
-func killProcess(process *os.Process, _ os.Signal) {
-	process.Kill()
-}

--- a/cli/run_windows.go
+++ b/cli/run_windows.go
@@ -1,0 +1,7 @@
+package cli
+
+import "os"
+
+func killProcess(process *os.Process, _ os.Signal) {
+	process.Kill()
+}


### PR DESCRIPTION
- [x] fix regexp for missing env file error (fixes https://github.com/dispatchrun/dispatch/issues/69)
- [x] add Windows runner on CI

We should use something platform-independent instead of `printenv`. I'm going to work on this in another PR