### PR TITLE
run: fix signal handling

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -281,6 +282,9 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 					}()
 				}
 			})
+
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
 
 			if err = cmd.Start(); err != nil {
 				return fmt.Errorf("failed to start %s: %v", strings.Join(args, " "), err)

--- a/cli/run_darwin.go
+++ b/cli/run_darwin.go
@@ -1,0 +1,7 @@
+package cli
+
+import "syscall"
+
+func setSysProcAttr(attr *syscall.SysProcAttr) {
+	attr.Setpgid = true
+}

--- a/cli/run_default.go
+++ b/cli/run_default.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package cli
 


### PR DESCRIPTION
Changes to signal handling:
* we spawn the child process in a new process group on macOS, like we were doing on Linux
* we forward whatever signal was first received, rather than unconditionally sending SIGTERM
* we forward the received signal to all processes in the process group


We're also now locking the OS thread before spawning the child process, to avoid issues with threads and `Pdeathsig` on Linux (this fixes https://github.com/dispatchrun/dispatch/issues/68).