### PR TITLE
add `dispatch init` command

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -163,8 +163,7 @@ func getAppDataDir(appName string) (string, error) {
 	return appDataDir, nil
 }
 
-func getLatestCommitSHA(repo string) (string, error) {
-	url := fmt.Sprintf(githubAPIURL, repo)
+func getLatestCommitSHA(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
@@ -305,7 +304,8 @@ func initCommand() *cobra.Command {
 			}
 
 			// get the latest commit SHA from the templates repository
-			remoteSHA, err := getLatestCommitSHA(repo)
+			url := fmt.Sprintf(githubAPIURL, repo)
+			remoteSHA, err := getLatestCommitSHA(url)
 			if err != nil {
 				cmd.Printf("failed to get latest commit SHA: %v", err)
 			}

--- a/cli/init.go
+++ b/cli/init.go
@@ -16,11 +16,9 @@ import (
 )
 
 const (
-	githubTarballURL = "https://github.com/%s/%s/tarball/%s"
-	githubAPIURL     = "https://api.github.com/repos/%s/%s/branches/%s"
-	owner            = "dispatchrun"
+	githubTarballURL = "https://github.com/dispatchrun/%s/tarball/main"
+	githubAPIURL     = "https://api.github.com/repos/dispatchrun/%s/branches/main"
 	repo             = "dispatch-examples"
-	branch           = "main"
 	dispatchUserDir  = "dispatch"
 )
 
@@ -62,7 +60,7 @@ func isDirectoryEmpty(path string) (bool, error) {
 }
 
 func downloadAndExtractTemplates(destDir string) error {
-	url := fmt.Sprintf(githubTarballURL, owner, repo, branch)
+	url := fmt.Sprintf(githubTarballURL, repo)
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -168,8 +166,8 @@ func getAppDataDir(appName string) (string, error) {
 	return appDataDir, nil
 }
 
-func getLatestCommitSHA(owner, repo, branch string) (string, error) {
-	url := fmt.Sprintf(githubAPIURL, owner, repo, branch)
+func getLatestCommitSHA(repo string) (string, error) {
+	url := fmt.Sprintf(githubAPIURL, repo)
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
@@ -312,7 +310,7 @@ func initCommand() *cobra.Command {
 				}
 			}
 
-			remoteSHA, err := getLatestCommitSHA(owner, repo, branch)
+			remoteSHA, err := getLatestCommitSHA(repo)
 			if err != nil {
 				cmd.Printf("failed to get latest commit SHA: %v", err)
 			}

--- a/cli/init.go
+++ b/cli/init.go
@@ -280,9 +280,9 @@ func copyFile(srcFile string, dstFile string) error {
 
 func initCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init <template> [path]",
-		Short: "Initialize a new Dispatch project",
-		// Args:  cobra.MinimumNArgs(1),
+		Use:     "init <template> [path]",
+		Short:   "Initialize a new Dispatch project",
+		GroupID: "dispatch",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get or create the Dispatch templates directory
 			dispatchUserDirPath, err := getAppDataDir(dispatchUserDir)

--- a/cli/init.go
+++ b/cli/init.go
@@ -1,0 +1,441 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	githubTarballURL = "https://github.com/%s/%s/tarball/%s"
+	githubAPIURL     = "https://api.github.com/repos/%s/%s/branches/%s"
+	owner            = "dispatchrun"
+	repo             = "dispatch-examples"
+	branch           = "main"
+	dispatchUserDir  = "dispatch"
+)
+
+// TODO: versioning for different SDKs?
+
+func directoryExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// The directory does not exist
+		return false, nil
+	}
+	if err != nil {
+		// Some other error occurred
+		return false, err
+	}
+	// Check if the path is a directory
+	return info.IsDir(), nil
+}
+
+func isDirectoryEmpty(path string) (bool, error) {
+	dir, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer dir.Close()
+
+	// Read directory names, limiting to one to check if it's not empty
+	_, err = dir.Readdirnames(1)
+	if err == nil {
+		// The directory is not empty
+		return false, nil
+	}
+	if err == io.EOF {
+		// The directory is empty
+		return true, nil
+	}
+	// Some other error occurred
+	return true, err
+}
+
+func downloadAndExtractTemplates(destDir string) error {
+	url := fmt.Sprintf(githubTarballURL, owner, repo, branch)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download templates: %s", resp.Status)
+	}
+
+	return extractTarball(resp.Body, destDir)
+}
+
+func extractTarball(r io.Reader, destDir string) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	var topLevelDir string
+
+	for {
+		header, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		case header == nil:
+			continue
+		}
+
+		// Get the top-level directory name
+		if topLevelDir == "" {
+			parts := strings.Split(header.Name, "/")
+			if len(parts) > 1 {
+				topLevelDir = parts[0]
+			}
+		}
+
+		// Strip the top-level directory from the file path
+		relPath := strings.TrimPrefix(header.Name, topLevelDir+"/")
+		target := filepath.Join(destDir, relPath)
+
+		// fmt.Printf("Extracting to %s\n", target)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(file, tr); err != nil {
+				file.Close()
+				return err
+			}
+			file.Close()
+		}
+	}
+}
+
+func getAppDataDir(appName string) (string, error) {
+	var configDir string
+	var err error
+
+	switch runtime.GOOS {
+	case "windows":
+		configDir, err = os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+	case "darwin":
+		configDir, err = os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+	default: // "linux" and other Unix-like systems
+		configDir = os.Getenv("XDG_CONFIG_HOME")
+		if configDir == "" {
+			configDir, err = os.UserConfigDir()
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
+	appDataDir := filepath.Join(configDir, appName)
+	err = os.MkdirAll(appDataDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	return appDataDir, nil
+}
+
+func getLatestCommitSHA(owner, repo, branch string) (string, error) {
+	url := fmt.Sprintf(githubAPIURL, owner, repo, branch)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get latest commit SHA: %s", resp.Status)
+	}
+
+	var result struct {
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return "", err
+	}
+
+	return result.Commit.SHA, nil
+}
+
+func readDirectories(path string) ([]string, error) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var directories []string
+	for _, file := range files {
+		if file.IsDir() {
+			directories = append(directories, file.Name())
+		}
+	}
+
+	return directories, nil
+}
+
+func cleanDirectory(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyDir(src string, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Construct the destination path
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			// Create the directory
+			if err := os.MkdirAll(dstPath, info.Mode()); err != nil {
+				return err
+			}
+		} else {
+			// Copy the file
+			if err := copyFile(path, dstPath); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func copyFile(srcFile string, dstFile string) error {
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+
+	// Copy file permissions
+	srcInfo, err := os.Stat(srcFile)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dstFile, srcInfo.Mode())
+}
+
+func initCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init <template> [path]",
+		Short: "Initialize a new Dispatch project",
+		Long:  "Initialize a new Dispatch project",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var directory string
+			var exists = true
+
+			dispatchUserDirPath, err := getAppDataDir(dispatchUserDir)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("failed to get Dispatch templates directory: %w", err)
+			}
+
+			dispatchTemplatesDirPath := filepath.Join(dispatchUserDirPath, "templates")
+			dispatchTemplatesHashPath := filepath.Join(dispatchUserDirPath, "templates.sha")
+
+			// read the latest commit SHA
+			sha, err := os.ReadFile(dispatchTemplatesHashPath)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("failed to read templates SHA: %w", err)
+				}
+			}
+
+			remoteSHA, err := getLatestCommitSHA(owner, repo, branch)
+			if err != nil {
+				cmd.Printf("failed to get latest commit SHA: %v", err)
+			}
+
+			if remoteSHA != "" && string(sha) != remoteSHA {
+				cmd.Println("Templates update available. Do you want to download the latest templates? [y/N]")
+
+				var response string
+				fmt.Scanln(&response)
+
+				if strings.ToLower(response) == "y" {
+					cmd.Printf("Downloading templates\n")
+					err = downloadAndExtractTemplates(dispatchTemplatesDirPath)
+					if err != nil {
+						cmd.Printf("failed to download and extract templates: %v", err)
+					} else {
+						cmd.Print("Templates have been updated\n")
+						// TODO: possible improvement:
+						// find which templates have been added/removed/modified
+						// and/or
+						// show last n commit messages as changes
+					}
+
+					// save the latest commit SHA
+					err = os.WriteFile(dispatchTemplatesHashPath, []byte(remoteSHA), 0644)
+					if err != nil {
+						cmd.Printf("failed to save templates SHA: %v", err)
+					}
+				}
+			}
+
+			templates, err := readDirectories(dispatchTemplatesDirPath)
+			if err != nil {
+				cmd.SilenceUsage = true
+				if os.IsNotExist(err) {
+					return fmt.Errorf("templates directory does not exist in %s. Please run `dispatch init` to download the templates", dispatchTemplatesDirPath)
+				}
+				return fmt.Errorf("failed to read templates directory. : %w", err)
+			}
+
+			wantedTemplate := args[0]
+			isTemplateFound := false
+
+			for _, template := range templates {
+				if template == wantedTemplate {
+					isTemplateFound = true
+					break
+				}
+			}
+
+			if !isTemplateFound {
+				cmd.SilenceUsage = true
+				cmd.Printf("Template %v is not supported.\nAvailable templates:\n", wantedTemplate)
+				for _, template := range templates {
+					cmd.Println("  " + template)
+				}
+				cmd.Println()
+				return nil
+			}
+
+			if len(args) > 1 {
+				directory = args[1]
+				flag, err := directoryExists(directory)
+				exists = flag
+
+				if err != nil {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("failed to check if directory exists: %w", err)
+				}
+
+				// create the directory if it doesn't exist
+				if !exists {
+					err := os.MkdirAll(directory, 0755)
+					if err != nil {
+						cmd.SilenceUsage = true
+						return fmt.Errorf("failed to create directory %v: %w", directory, err)
+					}
+					exists = true
+				}
+			} else {
+				directory = "."
+			}
+
+			if exists {
+				isEmpty, err := isDirectoryEmpty(directory)
+				if err != nil {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("failed to check if directory is empty: %w", err)
+				}
+				if !isEmpty {
+					cmd.Printf("Directory %v is not empty. Do you want to overwrite it? [y/N]\n", directory)
+
+					var response string
+					fmt.Scanln(&response)
+
+					if strings.ToLower(response) == "y" {
+						err := cleanDirectory(directory)
+						if err != nil {
+							cmd.SilenceUsage = true
+							return fmt.Errorf("failed to clean directory: %w", err)
+						}
+					} else {
+						return nil
+					}
+				}
+			}
+			path, err := filepath.Abs(directory)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("failed to get absolute path: %w", err)
+			}
+
+			cmd.Printf("Template %s was created in %s\n", wantedTemplate, path)
+
+			// copy the template to the destination
+			err = copyDir(filepath.Join(dispatchTemplatesDirPath, wantedTemplate), path)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("failed to copy template: %w", err)
+			}
+
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cli/init.go
+++ b/cli/init.go
@@ -18,7 +18,7 @@ import (
 const (
 	githubTarballURL = "https://github.com/%s/tarball/main"
 	githubAPIURL     = "https://api.github.com/repos/%s/branches/main"
-	repo             = "dispatchrun/dispatch-examples"
+	repo             = "dispatchrun/dispatch-templates"
 	dispatchUserDir  = "dispatch"
 )
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -312,29 +312,22 @@ func initCommand() *cobra.Command {
 
 			// update the templates if the latest commit SHA is different
 			if remoteSHA != "" && string(sha) != remoteSHA {
-				cmd.Println("Templates update available. Do you want to download the latest templates? [y/N]")
+				cmd.Printf("Downloading templates update...\n")
+				err = downloadAndExtractTemplates(dispatchTemplatesDirPath)
+				if err != nil {
+					cmd.Printf("failed to download and extract templates: %v", err)
+				} else {
+					cmd.Print("Templates have been updated\n\n")
+					// TODO: possible improvement:
+					// find which templates have been added/removed/modified
+					// and/or
+					// show last n commit messages as changes
+				}
 
-				var response string
-				fmt.Scanln(&response)
-
-				if strings.ToLower(response) == "y" {
-					cmd.Printf("Downloading templates\n")
-					err = downloadAndExtractTemplates(dispatchTemplatesDirPath)
-					if err != nil {
-						cmd.Printf("failed to download and extract templates: %v", err)
-					} else {
-						cmd.Print("Templates have been updated\n\n")
-						// TODO: possible improvement:
-						// find which templates have been added/removed/modified
-						// and/or
-						// show last n commit messages as changes
-					}
-
-					// save the latest commit SHA
-					err = os.WriteFile(dispatchTemplatesHashPath, []byte(remoteSHA), 0644)
-					if err != nil {
-						cmd.Printf("failed to save templates SHA: %v", err)
-					}
+				// save the latest commit SHA
+				err = os.WriteFile(dispatchTemplatesHashPath, []byte(remoteSHA), 0644)
+				if err != nil {
+					cmd.Printf("failed to save templates SHA: %v", err)
 				}
 			}
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -51,7 +51,7 @@ func isDirectoryEmpty(path string) (bool, error) {
 		return true, nil
 	}
 	// Some other error occurred
-	return true, err
+	return false, err
 }
 
 func downloadAndExtractTemplates(destDir string) error {

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -28,11 +28,15 @@ func TestInitCommand(t *testing.T) {
 		t.Parallel()
 
 		tempFile := t.TempDir() + "/tempfile"
-		_, err := os.Create(tempFile)
+		file, err := os.Create(tempFile)
 		assert.Nil(t, err)
 
 		result, _ := directoryExists(tempFile)
 		assert.False(t, result)
+
+		// Clean up
+		err = file.Close()
+		assert.Nil(t, err)
 	})
 
 	t.Run("isDirectoryEmpty returns true for empty directory", func(t *testing.T) {
@@ -50,11 +54,15 @@ func TestInitCommand(t *testing.T) {
 		tempDir := t.TempDir()
 
 		tempFile := tempDir + "/tempfile"
-		_, err := os.Create(tempFile)
+		file, err := os.Create(tempFile)
 		assert.Nil(t, err)
 
 		result, _ := isDirectoryEmpty(tempDir)
 		assert.False(t, result)
+
+		// Clean up
+		err = file.Close()
+		assert.Nil(t, err)
 	})
 
 	t.Run("downloadAndExtractTemplates downloads and extracts templates", func(t *testing.T) {
@@ -93,13 +101,17 @@ func TestInitCommand(t *testing.T) {
 		src := tempDir + "/srcfile"
 		dest := tempDir + "/destfile"
 
-		_, err := os.Create(src)
+		file, err := os.Create(src)
 		assert.Nil(t, err)
 
 		err = copyFile(src, dest)
 		assert.Nil(t, err)
 
 		_, err = os.Stat(dest)
+		assert.Nil(t, err)
+
+		// Clean up
+		err = file.Close()
 		assert.Nil(t, err)
 	})
 
@@ -127,7 +139,7 @@ func TestInitCommand(t *testing.T) {
 		tempDir := t.TempDir()
 
 		file := tempDir + "/file"
-		_, err := os.Create(file)
+		f, err := os.Create(file)
 		assert.Nil(t, err)
 
 		dir := tempDir + "/dir"
@@ -141,6 +153,10 @@ func TestInitCommand(t *testing.T) {
 		assert.NotNil(t, err)
 		_, err = os.Stat(dir)
 		assert.NotNil(t, err)
+
+		// Clean up
+		err = f.Close()
+		assert.Nil(t, err)
 	})
 
 	t.Run("readDirectories returns all subdirectories", func(t *testing.T) {

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -146,6 +146,10 @@ func TestInitCommand(t *testing.T) {
 		err = os.Mkdir(dir, 0755)
 		assert.Nil(t, err)
 
+		// Clean up
+		err = f.Close()
+		assert.Nil(t, err)
+
 		err = cleanDirectory(tempDir)
 		assert.Nil(t, err)
 
@@ -153,10 +157,6 @@ func TestInitCommand(t *testing.T) {
 		assert.NotNil(t, err)
 		_, err = os.Stat(dir)
 		assert.NotNil(t, err)
-
-		// Clean up
-		err = f.Close()
-		assert.Nil(t, err)
 	})
 
 	t.Run("readDirectories returns all subdirectories", func(t *testing.T) {

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -33,8 +33,6 @@ func TestInitCommand(t *testing.T) {
 
 		result, _ := directoryExists(tempFile)
 		assert.False(t, result)
-
-		os.Remove(tempFile)
 	})
 
 	t.Run("isDirectoryEmpty returns true for empty directory", func(t *testing.T) {
@@ -57,7 +55,35 @@ func TestInitCommand(t *testing.T) {
 
 		result, _ := isDirectoryEmpty(tempDir)
 		assert.False(t, result)
-
-		os.Remove(tempFile)
 	})
+
+	t.Run("downloadAndExtractTemplates downloads and extracts templates", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		err := downloadAndExtractTemplates(tempDir)
+		assert.Nil(t, err)
+
+		// Check if the templates directory was created
+		result, _ := isDirectoryEmpty(tempDir)
+		assert.False(t, result)
+	})
+
+	t.Run("getLatestCommitSHA returns the latest commit SHA", func(t *testing.T) {
+		t.Parallel()
+
+		sha, err := getLatestCommitSHA("https://api.github.com/repos/dispatchrun/dispatch/branches/main")
+		assert.Nil(t, err)
+		assert.Regexp(t, "^[a-f0-9]{40}$", sha)
+	})
+
+	t.Run("getLatestCommitSHA returns an error for invalid URL", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := getLatestCommitSHA("invalidurl")
+		assert.NotNil(t, err)
+	})
+
+	// t.Run("")
 }

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -133,32 +133,6 @@ func TestInitCommand(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("cleanDirectory removes all files and directories", func(t *testing.T) {
-		t.Parallel()
-
-		tempDir := t.TempDir()
-
-		file := tempDir + "/file"
-		f, err := os.Create(file)
-		assert.Nil(t, err)
-
-		dir := tempDir + "/dir"
-		err = os.Mkdir(dir, 0755)
-		assert.Nil(t, err)
-
-		// Clean up
-		err = f.Close()
-		assert.Nil(t, err)
-
-		err = cleanDirectory(tempDir)
-		assert.Nil(t, err)
-
-		_, err = os.Stat(file)
-		assert.NotNil(t, err)
-		_, err = os.Stat(dir)
-		assert.NotNil(t, err)
-	})
-
 	t.Run("readDirectories returns all subdirectories", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -85,5 +85,79 @@ func TestInitCommand(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
-	// t.Run("")
+	t.Run("copyFile copies file", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		src := tempDir + "/srcfile"
+		dest := tempDir + "/destfile"
+
+		_, err := os.Create(src)
+		assert.Nil(t, err)
+
+		err = copyFile(src, dest)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(dest)
+		assert.Nil(t, err)
+	})
+
+	t.Run("copyDir copies directory", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		src := tempDir + "/srcdir"
+		dest := tempDir + "/destdir"
+
+		err := os.Mkdir(src, 0755)
+		assert.Nil(t, err)
+
+		err = copyDir(src, dest)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(dest)
+		assert.Nil(t, err)
+	})
+
+	t.Run("cleanDirectory removes all files and directories", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		file := tempDir + "/file"
+		_, err := os.Create(file)
+		assert.Nil(t, err)
+
+		dir := tempDir + "/dir"
+		err = os.Mkdir(dir, 0755)
+		assert.Nil(t, err)
+
+		err = cleanDirectory(tempDir)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(file)
+		assert.NotNil(t, err)
+		_, err = os.Stat(dir)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("readDirectories returns all subdirectories", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		dir1 := tempDir + "/dir1"
+		err := os.Mkdir(dir1, 0755)
+		assert.Nil(t, err)
+
+		dir2 := tempDir + "/dir2"
+		err = os.Mkdir(dir2, 0755)
+		assert.Nil(t, err)
+
+		dirs, err := readDirectories(tempDir)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, []string{"dir1", "dir2"}, dirs)
+	})
 }

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCommand(t *testing.T) {
+	t.Run("directoryExists returns false for non-existent directory", func(t *testing.T) {
+		t.Parallel()
+
+		result, _ := directoryExists("nonexistentdirectory")
+		assert.False(t, result)
+	})
+
+	t.Run("directoryExists returns true for existing directory", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		result, _ := directoryExists(tempDir)
+		assert.True(t, result)
+	})
+
+	t.Run("directoryExists returns false for file", func(t *testing.T) {
+		t.Parallel()
+
+		tempFile := t.TempDir() + "/tempfile"
+		_, err := os.Create(tempFile)
+		assert.Nil(t, err)
+
+		result, _ := directoryExists(tempFile)
+		assert.False(t, result)
+
+		os.Remove(tempFile)
+	})
+
+	t.Run("isDirectoryEmpty returns true for empty directory", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		result, _ := isDirectoryEmpty(tempDir)
+		assert.True(t, result)
+	})
+
+	t.Run("isDirectoryEmpty returns false for non-empty directory", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		tempFile := tempDir + "/tempfile"
+		_, err := os.Create(tempFile)
+		assert.Nil(t, err)
+
+		result, _ := isDirectoryEmpty(tempDir)
+		assert.False(t, result)
+
+		os.Remove(tempFile)
+	})
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -44,6 +44,7 @@ func createMainCommand() *cobra.Command {
 
 	// Passing the global variables to the commands make testing in parallel possible.
 	cmd.AddCommand(loginCommand())
+	cmd.AddCommand(initCommand())
 	cmd.AddCommand(switchCommand(DispatchConfigPath))
 	cmd.AddCommand(verificationCommand())
 	cmd.AddCommand(runCommand())

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedCommands = []string{"login", "switch [organization]", "verification", "run", "version"}
+var expectedCommands = []string{"login", "switch [organization]", "verification", "run", "version", "init <template> [path]"}
 
 func TestMainCommand(t *testing.T) {
 	t.Run("Main command", func(t *testing.T) {
@@ -22,7 +22,6 @@ func TestMainCommand(t *testing.T) {
 		assert.Equal(t, "dispatch", groups[1].ID, "Expected second group to be 'dispatch'")
 
 		commands := cmd.Commands()
-		assert.Len(t, commands, 5, "Expected 5 commands")
 
 		// Extract the command IDs
 		commandIDs := make([]string, 0, len(commands))


### PR DESCRIPTION
This PR implements `dispatch init` command to initialize a new project.

### Usage
```sh
dispatch init <template> [path]
```
Where `<template>` is a required option and `[path]` is optional.

### Templates directory
On a first use the command will create an Application Data directory `dispatch`
- **Windows**: The application data directory is typically located at `%APPDATA%` or `%LOCALAPPDATA%`.
- **macOS**: The application data directory is typically located at `$HOME/Library/Application Support`.
- **Linux**: The application data directory is typically located at `$XDG_CONFIG_HOME or $HOME/.config`.

The App Data directory is used to save templates oh a user's computer to make them available for use later without Internet.
The directory has follows structure:
```
dispatch/
  templates/
    foo/
    bar/
  templates.sha
```

### Workflow

1) `dispatch init <template>` will try to get the SHA of the latest commit from the repository and compare it to local SHA. If values differ, Dispatch CLI will download update for templates first.
2) Dispatch CLI makes request to using GitHub REST API to download tarball of the latest commit and then extracts it into the Dispatch's App Data directory.
3) Finally, it copes template's files from the App Data directory (provided as `<template>` option) to a current working directory or to the `[path]` if it was provided.

If the destination directory is not empty, user will be asked if they want to clear the directory

<img width="595" alt="image" src="https://github.com/dispatchrun/dispatch/assets/1507086/e3f06655-a8d8-41cb-bddf-80ae0bcb1a42">

### Try it
```
git checkout init_command
make build
./build/darwin/arm64/dispatch init cat-facts ~/dispatch-template-test
```
This will create `cat-facts` template in the `dispatch-template-test` of your home directory.
Note that build directory can be different for your computer's arch and OS

To clear templates cache
```
rm -rf ~/Library/Application\ Support/dispatch
```
if you use MacOS

### Notes and open questions

- Current PR uses https://github.com/dispatchrun/dispatch-examples as a templates repo for the demonstration purpose only. We should introduce a new repo for templates.
- Should we introduce versioning for templates to make them compatible with different versions of SDKs? I think we should
- We can improve the templates update by adding information about which templates have been added/removed/modified or/and show last N commit messages and link to the full diff on GitHub between two SHAs
- Current implementation makes it pretty easy to add 3rd-party templates (as described in #59), but
  - it is easy to just use `git clone` instead (although `init`'s caching and templates updating features could be still useful)
  - we should signal user that it is a 3rd-party template and it's not maintained by dispatch.run
- ~~Should `dispatch init` go to the `Dispatch Commands` group or should it be in the `Additional Commands` in the `dispatch -h` output?~~ it's in the Dispatch group

--------
Closes #59